### PR TITLE
Solved Issue when using blur layer

### DIFF
--- a/SweetAlert/SweetAlert.swift
+++ b/SweetAlert/SweetAlert.swift
@@ -250,7 +250,12 @@ class SweetAlert: UIViewController {
     func showAlert(title: String, subTitle: String?, style: AlertStyle,buttonTitle: String,buttonColor: UIColor,otherButtonTitle:
         String?, otherButtonColor: UIColor?,action: ((isOtherButton: Bool) -> Void)? = nil) {
             userAction = action
-            let window = UIApplication.sharedApplication().keyWindow?.subviews.first as UIView
+
+//            let window = UIApplication.sharedApplication().keyWindow?.subviews.first as! UIView
+//            window.addSubview(view)
+
+            let window = UIApplication.sharedApplication().keyWindow?.viewForBaselineLayout() as UIView!
+
             window.addSubview(view)
             view.frame = window.bounds
             self.setupContentView()


### PR DESCRIPTION
When adding a blurEffect layer to the current UIView, SweetAlert pops the alert behind the blurLayer and you see alert blurred and not in focus (firstResponder).

To fix it, changes from this

let window = UIApplication.sharedApplication().keyWindow?.subviews.first as! UIView

to this

let window = UIApplication.sharedApplication().keyWindow?.viewForBaselineLayout() as UIView!
